### PR TITLE
#79: Added query parameter to randomize filename when downloading songs

### DIFF
--- a/Constants/FileExtensions.cs
+++ b/Constants/FileExtensions.cs
@@ -10,4 +10,7 @@ public class FileExtensions
 
     // Contains file extension with period at the beginning
     public static string JPG_EXTENSION = ".jpg";
+
+    // Contains file extension with period at the beginning
+    public static string ZIP_EXTENSION = ".zip";
 }

--- a/Controllers/Managers/DirectoryManager.cs
+++ b/Controllers/Managers/DirectoryManager.cs
@@ -1,3 +1,4 @@
+using System.Reflection.PortableExecutable;
 using Icarus.Models;
 using Icarus.Types;
 
@@ -50,13 +51,27 @@ public class DirectoryManager : BaseManager
         return new string(Enumerable.Repeat(chars, length).Select(s =>
             s[random.Next(s.Length)]).ToArray());
     }
+
+    public static string GenerateDownloadFilename(int length, string extension, string title, bool? randomize)
+    {
+        if (randomize.HasValue && randomize.Value) 
+        {
+            return GenerateFilename(length) + extension;
+        }
+        else
+        {
+            return title + extension;
+        }
+    }
+
     public void CreateDirectory()
     {
-        CreateDirectory(_song);
+        this.CreateDirectory(_song);
     }
+
     public void CreateDirectory(Song song)
     {
-        _song = song;
+        this._song = song;
 
         try
         {
@@ -77,6 +92,7 @@ public class DirectoryManager : BaseManager
             _logger.Error(msg, "An error occurred");
         }
     }
+
     public void DeleteEmptyDirectories()
     {
         try
@@ -100,6 +116,7 @@ public class DirectoryManager : BaseManager
             Console.WriteLine($"An error occurred {exMsg}");
         }
     }
+
     public void DeleteEmptyDirectories(Song song)
     {
         try
@@ -148,30 +165,42 @@ public class DirectoryManager : BaseManager
     {
         _logger.Info("Generating song path");
 
-        var songPath = string.Empty;
         var artistPath = ArtistDirectory(song);
         var albumPath = AlbumDirectory(song);
 
-        if (!Directory.Exists(artistPath))
+        GenerateDirectories(new List<DirEnt>{
+            new DirEnt
+            {
+                Pre = "Artist path does not exist",
+                Path = artistPath,
+                Post = "Creating artist path"
+            },
+            new DirEnt
+            {
+                Pre = "Album path does not exist",
+                Path = albumPath,
+                Post = "Created album path"
+            }
+        });
+
+        return albumPath;
+    }
+
+    private class DirEnt
+    {
+        public string Pre { get; set;}
+        public string Path { get; set; }
+        public string Post { get; set; }
+    }
+
+    private void GenerateDirectories(List<DirEnt> dirs)
+    {
+        foreach (var di in dirs)
         {
-            _logger.Info("Artist path does not exist");
-
-            Directory.CreateDirectory(artistPath);
-
-            _logger.Info("Creating artist path");
+            _logger.Info(di.Pre);
+            Directory.CreateDirectory(di.Path);
+            _logger.Info(di.Post);
         }
-        if (!Directory.Exists(albumPath))
-        {
-            _logger.Info("Album path does not exist");
-
-            Directory.CreateDirectory(albumPath);
-
-            _logger.Info("Created album path");
-        }
-
-        songPath = albumPath;
-
-        return songPath;
     }
 
     private void Initialize(DirectoryType dirTypes = DirectoryType.Music)

--- a/Controllers/Managers/DirectoryManager.cs
+++ b/Controllers/Managers/DirectoryManager.cs
@@ -48,6 +48,14 @@ public class DirectoryManager : BaseManager
 
 
     #region Methods
+    // Does not include extension
+    public static string GenerateFilename(int length)
+    {
+        string chars = Constants.DirectoryPaths.FILENAME_CHARACTERS;
+        var random = new Random();
+        return new string(Enumerable.Repeat(chars, length).Select(s =>
+            s[random.Next(s.Length)]).ToArray());
+    }
     public void CreateDirectory()
     {
         CreateDirectory(_song);

--- a/Controllers/Utilities/SongCompression.cs
+++ b/Controllers/Utilities/SongCompression.cs
@@ -85,7 +85,7 @@ public class SongCompression
 
         if (songDetails.Filename.Contains(Constants.FileExtensions.WAV_EXTENSION))
         {
-            _compressedSongFilename = StripMP3Extension(songDetails.Filename);
+            _compressedSongFilename = StripExtension(songDetails.Filename);
         }
 
         return tmpZipFilePath;
@@ -110,7 +110,7 @@ public class SongCompression
     }
 
 
-    string StripMP3Extension(string filename)
+    string StripExtension(string filename)
     {
         Console.WriteLine($"Before: {filename}");
         int filenameLength = filename.Length;
@@ -119,7 +119,7 @@ public class SongCompression
         var startIndex = endIndex - 3;
         Console.WriteLine($"Starting index {startIndex} and ending index {endIndex}");
         var stripped = filename.Remove(startIndex, 4);
-        stripped += ".zip";
+        stripped += Constants.FileExtensions.ZIP_EXTENSION;
         Console.WriteLine($"After {stripped}");
 
         return stripped;

--- a/Controllers/v1/CoverArtController.cs
+++ b/Controllers/v1/CoverArtController.cs
@@ -74,14 +74,15 @@ public class CoverArtController : BaseController
     }
 
     [HttpGet("data/download/{id}")]
-    public async Task<IActionResult> Download(int id)
+    public async Task<IActionResult> Download(int id, [FromQuery] bool? randomizeFilename)
     {
         var songContext = new SongContext(_connectionString);
         var covMgr = new CoverArtManager(this._config);
         
         var songMetaData = songContext.RetrieveRecord(new Song { SongID = id});
-        var filename = songMetaData.Title + Constants.FileExtensions.JPG_EXTENSION;
         var c = covMgr.GetCoverArt(songMetaData);
+
+        var filename = DirectoryManager.GenerateDownloadFilename(10, Constants.FileExtensions.JPG_EXTENSION, songMetaData.Title, randomizeFilename);
 
         var data = await c.GetData();
         

--- a/Controllers/v1/SongCompressedDataControllers.cs
+++ b/Controllers/v1/SongCompressedDataControllers.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Icarus.Controllers.Utilities;
 using Icarus.Models;
 using Icarus.Database.Contexts;
+using Icarus.Controllers.Managers;
 
 namespace Icarus.Controllers.V1;
 
@@ -49,16 +50,7 @@ public class SongCompressedDataController : BaseController
         var sng = context.RetrieveRecord(new Song{ SongID = id });
         SongData song = await cmp.RetrieveCompressedSong(sng);
 
-        var filename = string.Empty;
-
-        if (randomizeFilename.HasValue && randomizeFilename.Value) 
-        {
-            filename = Managers.DirectoryManager.GenerateFilename(10) + Constants.FileExtensions.ZIP_EXTENSION;
-        }
-        else
-        {
-            filename = sng.Title + Constants.FileExtensions.ZIP_EXTENSION;
-        }
+        var filename = DirectoryManager.GenerateDownloadFilename(10, Constants.FileExtensions.ZIP_EXTENSION, sng.Title, randomizeFilename);
 
         return File(song.Data, "application/x-msdownload", filename);
     }

--- a/Controllers/v1/SongDataController.cs
+++ b/Controllers/v1/SongDataController.cs
@@ -48,14 +48,24 @@ public class SongDataController : BaseController
 
 
     [HttpGet("download/{id}")]
-    public IActionResult Download(int id)
+    public IActionResult Download(int id, [FromQuery] bool? randomizeFilename)
     {
         var songContext = new SongContext(_connectionString);
         var songMetaData = songContext.RetrieveRecord(new Song { SongID = id});
         
         var song = _songMgr.RetrieveSong(songMetaData).Result;
+        var filename = "";
+
+        if (randomizeFilename.HasValue && randomizeFilename.Value) 
+        {
+            filename = Managers.DirectoryManager.GenerateFilename(10) + Constants.FileExtensions.WAV_EXTENSION;
+        }
+        else
+        {
+            filename = songMetaData.Title + Constants.FileExtensions.WAV_EXTENSION;
+        }
         
-        return File(song.Data, "application/x-msdownload", songMetaData.Filename);
+        return File(song.Data, "application/x-msdownload", filename);
     }
 
     // Assumes that the song already has metadata such as

--- a/Controllers/v1/SongDataController.cs
+++ b/Controllers/v1/SongDataController.cs
@@ -43,17 +43,8 @@ public class SongDataController : BaseController
         var songMetaData = songContext.RetrieveRecord(new Song { SongID = id});
         
         var song = _songMgr.RetrieveSong(songMetaData).Result;
-        var filename = "";
+        var filename = DirectoryManager.GenerateDownloadFilename(10, Constants.FileExtensions.WAV_EXTENSION, songMetaData.Title, randomizeFilename);
 
-        if (randomizeFilename.HasValue && randomizeFilename.Value) 
-        {
-            filename = Managers.DirectoryManager.GenerateFilename(10) + Constants.FileExtensions.WAV_EXTENSION;
-        }
-        else
-        {
-            filename = songMetaData.Title + Constants.FileExtensions.WAV_EXTENSION;
-        }
-        
         return File(song.Data, "application/x-msdownload", filename);
     }
 

--- a/Models/Song.cs
+++ b/Models/Song.cs
@@ -75,9 +75,7 @@ public class Song
     {
         int length = Constants.DirectoryPaths.FILENAME_LENGTH;
         string chars = Constants.DirectoryPaths.FILENAME_CHARACTERS;
-        var random = new Random();
-        var filename = new string(Enumerable.Repeat(chars, length).Select(s =>
-            s[random.Next(s.Length)]).ToArray());
+        var filename = this.Generate(length, chars);
         var extension = Icarus.Constants.FileExtensions.WAV_EXTENSION;
 
         return flag == 0 ? filename : $"{filename}{extension}";
@@ -87,15 +85,20 @@ public class Song
         int length = Constants.DirectoryPaths.FILENAME_LENGTH;
         string chars = Constants.DirectoryPaths.FILENAME_CHARACTERS;
         var extension = Icarus.Constants.FileExtensions.WAV_EXTENSION;
-        var random = new Random();
         var filename = await Task.Run(() =>
         {
-            return new string(Enumerable.Repeat(chars, length).Select(s =>
-                s[random.Next(s.Length)]).ToArray());
+            return this.Generate(length, chars);
         });
-        
 
         return flag == 0 ? filename : $"{filename}{extension}";
+    }
+
+    private string Generate(int length, string chars)
+    {
+        var random = new Random();
+        var filename = new string(Enumerable.Repeat(chars, length).Select(s =>
+            s[random.Next(s.Length)]).ToArray());
+        return filename;
     }
     #endregion
 }


### PR DESCRIPTION
When the `randomizeFilename` query parameter is provided, the filename of the downloaded media will be randomized or reflect the media's title. By default the value will be false.

Applied to the following endpoints:
* `GET api/v1/song/data/download/{song_id}`
* `GET api/v1/song/compressed/data/{song_id}`
* `GET api/v1/coverart/data/download/{song_id}`