### PR TITLE
bugfix: Create CoverArt endpoint message response is empty

### DIFF
--- a/src/callers/coverart.rs
+++ b/src/callers/coverart.rs
@@ -508,6 +508,7 @@ pub mod endpoint {
                         match super::cov_db::create(&pool, &coverart, &song.id).await {
                             Ok(id) => {
                                 coverart.id = id;
+                                response.message = String::from("Successful");
                                 response.data.push(coverart);
 
                                 (axum::http::StatusCode::OK, axum::Json(response))


### PR DESCRIPTION
Fixing bug where message in response was unpopulated on successful requests.